### PR TITLE
Filter the single page-open event before turning off analytics

### DIFF
--- a/components/metrics/WebsiteHeader.js
+++ b/components/metrics/WebsiteHeader.js
@@ -97,6 +97,8 @@ function objectToCSV(data) {
 
   csvRows.push(headers.join(','));
 
+  let filterNext = false;
+
   for (const row of data) {
     let values = headers
       .map(header => {
@@ -117,6 +119,15 @@ function objectToCSV(data) {
       });
 
     const urlPath = values[1].toLowerCase();
+    if (urlPath.includes('?uit')) {
+      filterNext = true;
+      continue;
+    } else if (filterNext) {
+      filterNext = false;
+
+      // Only skip this data entry if it's a page-open action
+      if (values[2].includes('Pagina geopend')) continue;
+    }
 
     if (urlPath.startsWith('/login') || urlPath.startsWith('/oauth') || urlPath.includes('?uit'))
       continue;


### PR DESCRIPTION
If dashboard is opened and then the analytics disable parameter is added, the page is refreshed, meaning we get 2 page opens. Second page open with the toggle is filtered but first isn't. This commit includes deleting the first one too.
I am aware this could result in data inconsistencies because this is not a solid way of doing it, and a fix is on the todo-list. For now this will be okay because the chance of producing a data inconsistency is relatively small.
